### PR TITLE
Updating to version of GA-SDK-ANDROID from 6.6.0 to 6.6.1

### DIFF
--- a/gameanalytics/manifests/android/build.gradle
+++ b/gameanalytics/manifests/android/build.gradle
@@ -4,6 +4,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.gameanalytics.sdk:gameanalytics-android:6.6.0'
+	implementation 'com.gameanalytics.sdk:gameanalytics-android:6.6.1'
 	implementation 'com.google.android.gms:play-services-appset:16.0.2'
 }


### PR DESCRIPTION
Updating to version of GA-SDK-ANDROID from 6.6.0 to 6.6.1 (latest is 7.0.0)

This fixes a GPGS dependency clash we are gettiing wih 6.6.0 when including extension_gpgs.

In 6.6.1 GA-SDK-ANDROID "removed com.google.android.gms.games dependency"

As discussed here:
https://forum.defold.com/t/integrating-gpgs-4-0-0-into-new-project/81677